### PR TITLE
Add jboss-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
 
+   <parent>
+      <groupId>org.jboss</groupId>
+      <artifactId>jboss-parent</artifactId>
+      <version>19</version>
+   </parent>
+
    <groupId>org.jboss.rh-messaging</groupId>
    <artifactId>rh-messaging-pom</artifactId>
    <version>1.0-SNAPSHOT</version>
@@ -33,17 +39,4 @@
          <organization>Red Hat</organization>
       </developer>
    </developers>
-
-   <distributionManagement>
-      <repository>
-         <id>jboss-releases-repository</id>
-         <name>JBoss Releases Repository</name>
-         <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
-      </repository>
-      <snapshotRepository>
-         <id>jboss-snapshots-repository</id>
-         <name>JBoss Snapshots Repository</name>
-         <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
-      </snapshotRepository>
-   </distributionManagement>
 </project>


### PR DESCRIPTION
I have used jboss-parent 19 to match the jboss-parent version used in the productized version of maven-apache-parent of ActiveMQ Artemis:

https://code.engineering.redhat.com/gerrit/gitweb?p=messaging/activemq-artemis.git;a=blob;f=pom.xml;h=25599b395448bc546ec4da271b5bc23ca54c1f73;hb=a0e6dcd24bede71ecab6edfa4ecaeb69cdc23c65#l28

https://code.engineering.redhat.com/gerrit/gitweb?p=apache/maven-pom.git;a=blob;f=pom.xml;h=6e99d0eb7ff4749e9ce6d02d31ea897b672fefa0;hb=95eb68617212662670a7cee67292d11888d23a80#l26